### PR TITLE
Add metric logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # pycharm
 .idea/
+
+# vscode
+.vscode/

--- a/baal/metrics/mixin.py
+++ b/baal/metrics/mixin.py
@@ -1,0 +1,78 @@
+from collections import defaultdict
+from numbers import Number
+from typing import Callable, Dict, Any, Optional, DefaultDict
+
+from baal.utils.metrics import Metrics
+
+
+class MetricMixin:
+    metrics: Dict[str, Metrics]
+    active_learning_metrics: DefaultDict[int, Dict[str, Any]]
+    _active_dataset_size: int
+
+    def active_step(self, dataset_size: Optional[int], metrics: Dict[str, Any]):
+        """
+        Log metrics at the end of the active learning step.
+
+        Args:
+            dataset_size: Current dataset size, if None, take state of `_active_dataset_size`.
+            metrics: Metrics values
+
+        Notes:
+            Metrics can be overridden.
+        """
+        if dataset_size is None:
+            dataset_size = self._active_dataset_size
+        self.active_learning_metrics[dataset_size].update(metrics)
+
+    def add_metric(self, name: str, initializer: Callable):
+        """
+        Add a baal.utils.metric.Metric to the Model.
+
+        Args:
+            name (str): name of the metric.
+            initializer (Callable): lambda to initialize a new instance of a
+                                    baal.utils.metrics.Metric object.
+        """
+        self.metrics["test_" + name] = initializer()
+        self.metrics["train_" + name] = initializer()
+
+    def _reset_metrics(self, filter=""):
+        """
+        Reset all Metrics according to a filter.
+
+        Args:
+            filter (str): Only keep the metric if `filter` in the name.
+        """
+        for k, v in self.metrics.items():
+            if filter in k:
+                v.reset()
+
+    def get_metrics(self, filter="") -> Dict[str, Any]:
+        """
+        Get all Metric values according to a filter.
+
+        Args:
+            filter (str): Only keep the metric if `filter` in the name.
+
+        Returns:
+            Dictionary with all values
+        """
+        return {met_name: met.value for met_name, met in self.metrics.items() if filter in met_name}
+
+    def _update_metrics(self, out, target, loss, filter=""):
+        """
+        Update all metrics.
+
+        Args:
+            out (Tensor): Prediction.
+            target (Tensor): Ground truth.
+            loss (Tensor): Loss from the criterion.
+            filter (str): Only update metrics according to this filter.
+        """
+        for k, v in self.metrics.items():
+            if filter in k:
+                if "loss" in k:
+                    v.update(loss)
+                else:
+                    v.update(out, target)

--- a/baal/metrics/mixin.py
+++ b/baal/metrics/mixin.py
@@ -58,7 +58,13 @@ class MetricMixin:
         Returns:
             Dictionary with all values
         """
-        return {met_name: met.value for met_name, met in self.metrics.items() if filter in met_name}
+        metrics = {
+            met_name: met.value for met_name, met in self.metrics.items() if filter in met_name
+        }
+        if self._active_dataset_size != -1:
+            # Add dataset size if it was ever set.
+            metrics.update({"dataset_size": self._active_dataset_size})
+        return metrics
 
     def _update_metrics(self, out, target, loss, filter=""):
         """

--- a/baal/modelwrapper.py
+++ b/baal/modelwrapper.py
@@ -131,7 +131,7 @@ class ModelWrapper(MetricMixin):
             )
 
         log.info("Evaluation complete", test_loss=self.metrics["test_loss"].value)
-        self.active_step(None, self.get_metrics("train"))
+        self.active_step(None, self.get_metrics("test"))
         return self.metrics["test_loss"].value
 
     def train_and_test_on_datasets(

--- a/baal/modelwrapper.py
+++ b/baal/modelwrapper.py
@@ -1,4 +1,5 @@
 import sys
+from collections import defaultdict
 from collections.abc import Sequence
 from copy import deepcopy
 from typing import Callable, Optional
@@ -11,6 +12,7 @@ from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.dataloader import default_collate
 from tqdm import tqdm
 
+from baal.metrics.mixin import MetricMixin
 from baal.utils.array_utils import stack_in_memory
 from baal.utils.cuda_utils import to_cuda
 from baal.utils.iterutils import map_on_tensor
@@ -27,7 +29,7 @@ def _stack_preds(out):
     return out
 
 
-class ModelWrapper:
+class ModelWrapper(MetricMixin):
     """
     Wrapper created to ease the training/testing/loading.
 
@@ -41,48 +43,10 @@ class ModelWrapper:
         self.model = model
         self.criterion = criterion
         self.metrics = dict()
+        self.active_learning_metrics = defaultdict(dict)
         self.add_metric("loss", lambda: Loss())
         self.replicate_in_memory = replicate_in_memory
-
-    def add_metric(self, name: str, initializer: Callable):
-        """
-        Add a baal.utils.metric.Metric to the Model.
-
-        Args:
-            name (str): name of the metric.
-            initializer (Callable): lambda to initialize a new instance of a
-                                    baal.utils.metrics.Metric object.
-        """
-        self.metrics["test_" + name] = initializer()
-        self.metrics["train_" + name] = initializer()
-
-    def _reset_metrics(self, filter=""):
-        """
-        Reset all Metrics according to a filter.
-
-        Args:
-            filter (str): Only keep the metric if `filter` in the name.
-        """
-        for k, v in self.metrics.items():
-            if filter in k:
-                v.reset()
-
-    def _update_metrics(self, out, target, loss, filter=""):
-        """
-        Update all metrics.
-
-        Args:
-            out (Tensor): Prediction.
-            target (Tensor): Ground truth.
-            loss (Tensor): Loss from the criterion.
-            filter (str): Only update metrics according to this filter.
-        """
-        for k, v in self.metrics.items():
-            if filter in k:
-                if "loss" in k:
-                    v.update(loss)
-                else:
-                    v.update(out, target)
+        self._active_dataset_size = -1
 
     def train_on_dataset(
         self,
@@ -111,9 +75,11 @@ class ModelWrapper:
         Returns:
             The training history.
         """
+        dataset_size = len(dataset)
         self.train()
+        self.set_dataset_size(dataset_size)
         history = []
-        log.info("Starting training", epoch=epoch, dataset=len(dataset))
+        log.info("Starting training", epoch=epoch, dataset=dataset_size)
         collate_fn = collate_fn or default_collate
         for _ in range(epoch):
             self._reset_metrics("train")
@@ -125,6 +91,7 @@ class ModelWrapper:
 
         optimizer.zero_grad()  # Assert that the gradient is flushed.
         log.info("Training complete", train_loss=self.metrics["train_loss"].value)
+        self.active_step(dataset_size, self.get_metrics("train"))
         return history
 
     def test_on_dataset(
@@ -163,6 +130,7 @@ class ModelWrapper:
             )
 
         log.info("Evaluation complete", test_loss=self.metrics["test_loss"].value)
+        self.active_step(None, self.get_metrics("train"))
         return self.metrics["test_loss"].value
 
     def train_and_test_on_datasets(
@@ -465,6 +433,15 @@ class ModelWrapper:
                 getattr(m, "reset_parameters", lambda: None)()
 
         self.model.apply(reset)
+
+    def set_dataset_size(self, dataset_size: int):
+        """
+        Set state for dataset size. Useful for tracking.
+
+        Args:
+            dataset_size: Dataset state
+        """
+        self._active_dataset_size = dataset_size
 
 
 def mc_inference(model, data, iterations, replicate_in_memory):

--- a/baal/utils/pytorch_lightning.py
+++ b/baal/utils/pytorch_lightning.py
@@ -76,9 +76,9 @@ class ActiveLightningModule(LightningModule):
         # Get the input only.
         x, _ = batch
         # Perform Monte-Carlo Inference fro I iterations.
-        out = mc_inference(self, x,
-                           self.hparams.iterations,  # type: ignore
-                           self.hparams.replicate_in_memory)  # type: ignore
+        out = mc_inference(
+            self, x, self.hparams.iterations, self.hparams.replicate_in_memory  # type: ignore
+        )  # type: ignore
         return out
 
 

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -5,6 +5,32 @@
 
 To work with `baal.modelwrapper.ModelWrapper`, we provide `Metrics`.
 
+
+### Examples
+
+```python
+from baal.modelwrapper import ModelWrapper
+from baal.utils.metrics import Accuracy
+
+wrapper : ModelWrapper = ...
+# You can add any metrics from `baal.utils.metrics`.
+wrapper.add_metric(name='accuracy',initializer=lambda : Accuracy())
+
+# Metrics are automatically set when training and evaluating.
+wrapper.train_on_dataset(...)
+wrapper.test_on_dataset(...)
+
+print(wrapper.get_metrics())
+"""
+>>> {'dataset_size': 200,
+    'test_accuracy': 0.26038339734077454,
+    'test_loss': 2.190103769302368,
+    'train_accuracy': 0.3214285671710968,
+    'train_loss': 2.1795670986175537}
+...
+"""
+```
+
 ```eval_rst
 .. automodule:: baal.utils.metrics
     :members:

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -27,7 +27,17 @@ print(wrapper.get_metrics())
     'test_loss': 2.190103769302368,
     'train_accuracy': 0.3214285671710968,
     'train_loss': 2.1795670986175537}
-...
+"""
+
+# Get metrics per dataset_size (state is kept for the entire loop.
+print(wrapper.active_learning_metrics)
+"""
+>>> {200: {'dataset_size': 200,
+    'test_accuracy': 0.26038339734077454,
+    'test_loss': 2.190103769302368,
+    'train_accuracy': 0.3214285671710968,
+    'train_loss': 2.1795670986175537},
+    ...
 """
 ```
 

--- a/experiments/mlp_mcdropout.py
+++ b/experiments/mlp_mcdropout.py
@@ -62,13 +62,7 @@ for step in range(100):
     )
     test_loss = wrapper.test_on_dataset(test_ds, batch_size=32, use_cuda=use_cuda)
 
-    pprint(
-        {
-            "dataset_size": len(al_dataset),
-            "train_loss": wrapper.metrics["train_loss"].value,
-            "test_loss": wrapper.metrics["test_loss"].value,
-        }
-    )
+    pprint(wrapper.get_metrics())
     flag = al_loop.step()
     if not flag:
         # We are done labelling! stopping

--- a/experiments/mlp_regression_mcdropout.py
+++ b/experiments/mlp_regression_mcdropout.py
@@ -103,13 +103,7 @@ for step in range(1000):
     )
     test_loss = wrapper.test_on_dataset(test_ds, batch_size=16, use_cuda=use_cuda, workers=0)
 
-    pprint(
-        {
-            "dataset_size": len(al_dataset),
-            "train_loss": wrapper.metrics["train_loss"].value,
-            "test_loss": wrapper.metrics["test_loss"].value,
-        }
-    )
+    pprint(wrapper.get_metrics())
     flag = al_loop.step()
     if not flag:
         # We are done labelling! stopping

--- a/experiments/vgg_mcdropout_cifar10.py
+++ b/experiments/vgg_mcdropout_cifar10.py
@@ -1,4 +1,5 @@
 import argparse
+from pprint import pprint
 import random
 from copy import deepcopy
 
@@ -115,7 +116,7 @@ def main():
     # We will reset the weights at each active learning step.
     init_weights = deepcopy(model.state_dict())
 
-    for epoch in tqdm(range(args.epoch)):
+    for _ in tqdm(range(args.epoch)):
         # Load the initial weights.
         model.load_state_dict(init_weights)
         model.train_on_dataset(
@@ -128,20 +129,11 @@ def main():
 
         # Validation!
         model.test_on_dataset(test_set, hyperparams["batch_size"], use_cuda)
-        metrics = model.metrics
         should_continue = active_loop.step()
         if not should_continue:
             break
 
-        val_loss = metrics["test_loss"].value
-        logs = {
-            "val": val_loss,
-            "epoch": epoch,
-            "train": metrics["train_loss"].value,
-            "labeled_data": active_set.labelled,
-            "Next Training set size": len(active_set),
-        }
-        print(logs)
+        pprint(model.get_metrics())
 
 
 if __name__ == "__main__":

--- a/tests/metrics/test_mixin.py
+++ b/tests/metrics/test_mixin.py
@@ -1,0 +1,52 @@
+import numpy as np
+import torch
+from baal.modelwrapper import ModelWrapper
+from baal.utils.metrics import Accuracy, Precision
+
+
+def test_active_step():
+    wrapper = ModelWrapper(None, None)
+    precisions = np.linspace(0,1, 10, endpoint=False)
+    recalls = np.linspace(0.5, 1, 10, endpoint=False)
+    dataset_size = list(range(100, 1100, 100))
+    for ds_size, precision, recall in zip(dataset_size, precisions, recalls):
+        wrapper.active_step(ds_size, {
+            'Precision': precision,
+            'Recall': recall
+        })
+    assert len(wrapper.active_learning_metrics) == 10
+    assert wrapper.active_learning_metrics[100] == {
+        'Precision': 0.0,
+        'Recall': 0.5
+    }
+    
+    wrapper = ModelWrapper(None, None)
+    wrapper.set_dataset_size(1000)
+    wrapper.active_step(dataset_size=None, metrics={
+        'Precision': 0.1,
+        'Recall': 0.2
+    })
+    assert wrapper._active_dataset_size == 1000
+    assert wrapper.active_learning_metrics == {
+        1000: {
+        'Precision': 0.1,
+        'Recall': 0.2
+    }
+    }
+
+def test_get_metrics():
+    wrapper = ModelWrapper(None, None)
+    wrapper.add_metric('accuracy', Accuracy)
+
+    assert len(wrapper.get_metrics()) == 4
+    assert len(wrapper.get_metrics('test')) == 2
+    assert all('test' in ki for ki in wrapper.get_metrics('test'))
+    assert len(wrapper.get_metrics('train')) == 2
+    assert all('train' in ki for ki in wrapper.get_metrics('train'))
+
+    wrapper.set_dataset_size(1000)
+    assert len(wrapper.get_metrics()) == 5
+    assert len(wrapper.get_metrics('test')) == 3
+    assert sum('test' in ki for ki in wrapper.get_metrics('test')) == 2
+    assert len(wrapper.get_metrics('train')) == 3
+    assert sum('train' in ki for ki in wrapper.get_metrics('train')) == 2


### PR DESCRIPTION
## Summary:

Add some utils to keep track of metrics over time.

This is WIP, but what do you think of this API?
It would be quite simple for the users to get a metrics for each dataset size.

We can also add utilities for that such as `MetricMixin.get_active_metric(metric_name="precision") : Dict[int, float]`

### Features:

Fixes #220 

## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [ ] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
