### PR TITLE
Support for Partial Monte-Carlo dropout

### DIFF
--- a/baal/modelwrapper.py
+++ b/baal/modelwrapper.py
@@ -388,7 +388,15 @@ class ModelWrapper(MetricMixin):
                 out = map_on_tensor(lambda o: o.view([iterations, -1, *o.size()[1:]]), out)
                 out = map_on_tensor(lambda o: o.permute(1, 2, *range(3, o.ndimension()), 0), out)
             else:
-                out = [self.model(data) for _ in range(iterations)]
+                try:
+                    func_list = dir(self.model.module)
+                except:
+                    func_list = []
+                    
+                if "montecarlo_forward" in func_list:
+                    out = self.model.module.montecarlo_forward(data, iterations)
+                else:
+                    out = [self.model(data) for _ in range(iterations)]
                 out = _stack_preds(out)
             return out
 


### PR DESCRIPTION
https://github.com/baal-org/baal/discussions/252#discussioncomment-5212884

## Summary:
Support for Partial Monte-Carlo dropout in modelwrapper.py. This procedure supports the execution of a custom made function called **montecarlo_forward** in the model class. If this montecarlo_forward function is not present, then execute the standard repeated image analysis. 

Montecarlo_forward is an altered forward pass that only iterates the network parts that have dropout. Because there can be different ways of placing the dropout, this function should be custom made (also assuming that there can be different neural network architectures and different forward passes). 

### Features:


## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [ ] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
