### PR TITLE
added setting to skip x epochs when using  train_and_test_on_datasets

### DIFF
--- a/baal/modelwrapper.py
+++ b/baal/modelwrapper.py
@@ -148,7 +148,7 @@ class ModelWrapper(MetricMixin):
         return_best_weights=False,
         patience=None,
         min_epoch_for_es=0,
-        skip_epochs=1
+        skip_epochs=1,
     ):
         """
         Train and test the model on both Dataset `train_dataset`, `test_dataset`.
@@ -179,8 +179,10 @@ class ModelWrapper(MetricMixin):
             _ = self.train_on_dataset(
                 train_dataset, optimizer, batch_size, 1, use_cuda, workers, collate_fn, regularizer
             )
-            if e%skip_epochs==0:
-                te_loss = self.test_on_dataset(test_dataset, batch_size, use_cuda, workers, collate_fn)
+            if e % skip_epochs == 0:
+                te_loss = self.test_on_dataset(
+                    test_dataset, batch_size, use_cuda, workers, collate_fn
+                )
                 hist.append(self.get_metrics())
                 if te_loss < best_loss:
                     best_epoch = e

--- a/baal/modelwrapper.py
+++ b/baal/modelwrapper.py
@@ -191,7 +191,6 @@ class ModelWrapper(MetricMixin):
                 if patience is not None and (e - best_epoch) > patience and (e > min_epoch_for_es):
                     # Early stopping
                     break
-                hist.append(self.get_metrics())
             else:
                 hist.append(self.get_metrics("train"))
 

--- a/baal/modelwrapper.py
+++ b/baal/modelwrapper.py
@@ -168,6 +168,7 @@ class ModelWrapper(MetricMixin):
                                         `patience` epoch without improvement.
             min_epoch_for_es (int): Epoch at which the early stopping starts.
             skip_epochs (int): Number of epochs to skip for test_on_dataset
+
         Returns:
             History and best weights if required.
         """


### PR DESCRIPTION
## Summary:
For training it is not desirable to test at every epoch. This simple update solves this issue. By using a skip_epochs option in train_and_test_on_datasets

## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [ ] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
