### PR TITLE
Improve get_indices_for_active_step by caching the result according t…

### DIFF
--- a/baal/active/dataset/base.py
+++ b/baal/active/dataset/base.py
@@ -50,17 +50,17 @@ class SplittedDataset(Dataset):
         Returns:
             List of the selected indices for training.
         """
-        if self.current_al_step != self._indices_cache[0]:
+        if (curr_al_step := self.current_al_step) != self._indices_cache[0]:
             if self.last_active_steps == -1:
                 min_labelled_step = 0
             else:
-                min_labelled_step = max(0, self.current_al_step - self.last_active_steps)
+                min_labelled_step = max(0, curr_al_step- self.last_active_steps)
 
             # we need to work with lists since arrow dataset is not compatible with np.int types!
             indices = [
                 indx for indx, val in enumerate(self.labelled_map) if val > min_labelled_step
             ]
-            self._indices_cache = (self.current_al_step, indices)
+            self._indices_cache = (curr_al_step, indices)
         return self._indices_cache[1]
 
     def is_labelled(self, idx: int) -> bool:

--- a/baal/active/dataset/base.py
+++ b/baal/active/dataset/base.py
@@ -54,7 +54,7 @@ class SplittedDataset(Dataset):
             if self.last_active_steps == -1:
                 min_labelled_step = 0
             else:
-                min_labelled_step = max(0, curr_al_step- self.last_active_steps)
+                min_labelled_step = max(0, curr_al_step - self.last_active_steps)
 
             # we need to work with lists since arrow dataset is not compatible with np.int types!
             indices = [

--- a/baal/active/dataset/numpy.py
+++ b/baal/active/dataset/numpy.py
@@ -68,5 +68,6 @@ class ActiveNumpyArray(SplittedDataset):
         if not isinstance(value, (list, tuple)):
             value = [value]
         indexes = self._pool_to_oracle_index(index)
+        active_step = self.current_al_step + 1
         for index, val in zip_longest(indexes, value, fillvalue=None):
-            self.labelled_map[index] = 1
+            self.labelled_map[index] = active_step


### PR DESCRIPTION
…o the current AL step

## Summary:

A faster way would be to clear the cache only when we call `label`, but that would break the encapsulation IMO. So leaving it at that, it is still 10x better.

### Features:


## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [ ] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
