### PR TITLE
docs: use correct link to experiment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ docker run --rm baal --gpus all python3 experiments/vgg_mcdropout_cifar10.py
 ### Use Baal for YOUR Experiments
 
 Simply clone the repo, and create your own experiment script similar to the example
-at [experiments/vgg_experiment.py](experiments/vgg_experiment.py). Make sure to use the four main parts of Baal
+at _[experiments/vgg_mcdropout_cifar10.py](experiments/vgg_mcdropout_cifar10.py)_. Make sure to use the four main parts of Baal
 framework. _Happy running experiments_
 
 ### Contributing!


### PR DESCRIPTION
## Summary:

### Features:

The hyperlink to file `experiments/vgg_experiment.py` did not work because the file does not exist (anymore). As such, I referred to the file `vgg_mcdropout_cifar10.py` which is already referenced in the README as a "complete experiment".

## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [ ] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
