### PR TITLE
`weights=None` in vgg models

### DIFF
--- a/experiments/ssl_experiments/pimodel_cifar10.py
+++ b/experiments/ssl_experiments/pimodel_cifar10.py
@@ -289,7 +289,7 @@ if __name__ == "__main__":
     print("Active set length: {}".format(len(active_set)))
     print("Pool set length: {}".format(len(active_set.pool)))
 
-    net = vgg11(pretrained=False, num_classes=10)
+    net = vgg11(weights=None, num_classes=10)
 
     weights = load_state_dict_from_url("https://download.pytorch.org/models/vgg11-bbd30ac9.pth")
     weights = {k: v for k, v in weights.items() if "classifier.6" not in k}

--- a/experiments/ssl_experiments/pimodel_mcdropout_cifar10.py
+++ b/experiments/ssl_experiments/pimodel_mcdropout_cifar10.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
     print("Pool set length: {}".format(len(active_set.pool)))
 
     heuristic = get_heuristic(params.heuristic)
-    model = vgg16(pretrained=False, num_classes=10)
+    model = vgg16(weights=None, num_classes=10)
     weights = load_state_dict_from_url("https://download.pytorch.org/models/vgg16-397923af.pth")
     weights = {k: v for k, v in weights.items() if "classifier.6" not in k}
     model.load_state_dict(weights, strict=False)

--- a/experiments/vgg_mcdropout_cifar10.py
+++ b/experiments/vgg_mcdropout_cifar10.py
@@ -84,7 +84,7 @@ def main():
 
     heuristic = get_heuristic(hyperparams["heuristic"], hyperparams["shuffle_prop"])
     criterion = CrossEntropyLoss()
-    model = vgg16(pretrained=False, num_classes=10)
+    model = vgg16(weights=None, num_classes=10)
     weights = load_state_dict_from_url("https://download.pytorch.org/models/vgg16-397923af.pth")
     weights = {k: v for k, v in weights.items() if "classifier.6" not in k}
     model.load_state_dict(weights, strict=False)


### PR DESCRIPTION
## Summary:
Fixes the "UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=None`."

### Features:


## Checklist:

* [ ] Your code is documented (To validate this, add your module to `tests/documentation_test.py`).
* [x] Your code is tested with unit tests.
* [ ] You moved your Issue to the PR state.
